### PR TITLE
Add channel for realtime game

### DIFF
--- a/core/consumers.py
+++ b/core/consumers.py
@@ -1,0 +1,304 @@
+import asyncio
+import json
+import random
+import time
+from typing import List
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from django.utils import timezone
+from rest_framework.exceptions import APIException
+
+from core.models import Match, Room, SelectedWord, Word
+
+
+class LogicError(APIException):
+    default_detail = 'Business logic error.'
+    default_code = 'logic_error'
+
+
+class PermissionDenied(APIException):
+    default_detail = 'Permission denied.'
+    default_code = 'permission_denied'
+
+
+class WordSetupError(APIException):
+    default_detail = 'Words are not available at the moment'
+    default_code = 'words_unavailable'
+
+
+@database_sync_to_async
+def get_room_and_check_turn(
+        user,
+        pk,
+        expected_states: List[Match.State]
+):
+    room = Room.objects.get(pk=pk)
+    players = room.players.values_list(
+        'username', flat=True).order_by('username')
+    if user.username not in players:
+        raise PermissionDenied(detail='You are not member of this room')
+
+    if not hasattr(room, 'match'):
+        raise LogicError(detail='Room\'s match is not started yet')
+
+    if room.match.state not in expected_states:
+        raise LogicError(
+            detail=f'Match\'s state is not in {expected_states}'
+        )
+
+    if players[room.match.current_turn] != user.username:
+        raise PermissionDenied(detail='This is not your turn')
+
+    return room
+
+
+@database_sync_to_async
+def is_guessing(
+    user,
+    pk
+):
+    room = Room.objects.get(pk=pk)
+    players = room.players.values_list(
+        'username', flat=True).order_by('username')
+    guesser_index = (room.match.current_turn + 2) % 4
+    return players[guesser_index] == user.username
+
+
+@database_sync_to_async
+def add_score_to_team(room: Room, score: int, save: bool = True) -> None:
+    team = None
+    if room.teams == Room.Teams.ONE_TWO__THREE_FOUR:
+        team = 0 if room.match.current_turn in [0, 1] else 1
+    elif room.teams == Room.Teams.ONE_THREE__TWO_FOUR:
+        team = 0 if room.match.current_turn in [0, 2] else 1
+    elif room.teams == Room.Teams.ONE_FOUR__TWO_THREE:
+        team = 0 if room.match.current_turn in [0, 3] else 1
+
+    if team is None:
+        return
+
+    if team == 0:
+        room.match.team_one_score += score
+    else:
+        room.match.team_two_score += score
+
+    if save:
+        room.match.save()
+
+
+# @cache
+@database_sync_to_async
+def get_words_all_indices(complexity: int) -> List[int]:
+    """
+    Following query result will be cached, so we should reload
+    our web app after each time we modified `Word` table.
+    """
+    return Word.objects.filter(
+        complexity=complexity
+    ).values_list(
+        'id',
+        flat=True
+    ).order_by('id')
+
+
+async def get_random_word() -> Word:
+    complexity = random.choices(
+        [
+            Word.Complexity.EASY,
+            Word.Complexity.INTERMEDIATE,
+            Word.Complexity.HARD,
+        ],
+        weights=[
+            4,
+            2,
+            1
+        ],
+        k=1
+    )
+    indices = await get_words_all_indices(complexity[0])
+    return await get_random_word_with_indices(indices)
+
+
+@database_sync_to_async
+def get_random_word_with_indices(indices):
+    if len(indices) == 0:
+        raise WordSetupError()
+    return Word.objects.get(pk=indices[random.randint(0, len(indices) - 1)])
+
+
+@database_sync_to_async
+def play_room_match(room):
+    room.match.state = Match.State.PLAYING
+    room.match.round_start_time = timezone.now()
+    room.match.save()
+
+
+@database_sync_to_async
+def finish_room_match_round(room):
+    room.match.state = Match.State.WAITING
+    room.match.current_round += 1
+    room.match.current_turn = (room.match.current_round + 1) % 4
+    room.match.save()
+
+
+class TestConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        self.room_pk = int(self.scope['url_route']['kwargs']['pk'])
+        self.user = self.scope['user']
+        self.room_group_name = 'room_%d' % self.room_pk
+
+        # TODO: check user-related stuff (auth? room-related?)
+        if not self.user.is_authenticated:
+            await self.close()
+            return
+
+        # Join room group
+        await self.channel_layer.group_add(
+            self.room_group_name,
+            self.channel_name
+        )
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        # Leave room group
+        await self.channel_layer.group_discard(
+            self.room_group_name,
+            self.channel_name
+        )
+
+    async def receive_json(self, data):
+        action = data.get('action')
+        if not action:
+            return
+        try:
+            if action == 'play':
+                await self.play()
+            if action == 'skip':
+                await self.skip()
+            if action == 'correct':
+                await self.correct()
+        except Exception as e:
+            await self.send_json({
+                'message': str(e)
+            })
+
+    # Receive message from room group
+    async def room_event(self, event):
+        if 'error' in event:
+            await self.send(text_data=json.dumps({
+                'message': event['error']
+            }))
+            return
+
+        message = event['message']
+        if await is_guessing(self.user, self.room_pk):
+            message = "<-Guessing->"
+        # Send message to WebSocket
+        await self.send_json({
+            'message': message
+        })
+
+    async def finish_round(self, on):
+        await asyncio.sleep(on - time.time())
+
+        # TODO: New Round
+        room = await database_sync_to_async(
+            lambda: Room.objects.get(pk=self.room_pk)
+        )()
+        await finish_room_match_round(room)
+
+        await self.send_json({
+            'type': 'room_event',
+            'message': 'round finished'
+        })
+
+    async def play(self):
+        """
+        Play match and return first word
+
+        Only the explaining player can call this endpoint.
+
+        Return: A simple word that explaining player should explain
+
+        """
+        room = await get_room_and_check_turn(self.user, self.room_pk, [
+            Match.State.NEWBORN,
+            Match.State.WAITING,
+        ])
+
+        word = await get_random_word()
+        await database_sync_to_async(lambda: SelectedWord.objects.create(
+            text=word,
+            match=room.match
+        ))()
+
+        await play_room_match(room)
+
+        # TODO: Notify others
+        await self.channel_layer.group_send(self.room_group_name, {
+            'type':    'room_event',
+            'message': word.text
+        })
+
+        asyncio.create_task(self.finish_round(int(time.time()) + 30))
+
+        # TODO: Schedule round ending task using channel and native `await`
+        # https://github.com/django/channels/issues/814#issuecomment-354708463
+
+    async def correct(self):
+        """
+        Add correct guess score to explaining player's team and get next word
+
+        Only the explaining player can call this endpoint.
+
+        Return: A simple word that explaining player should explain
+        as next word
+
+        """
+        room = await get_room_and_check_turn(self.user, self.room_pk, [
+            Match.State.PLAYING,
+        ])
+
+        word = await get_random_word()
+        await database_sync_to_async(lambda: SelectedWord.objects.create(
+            text=word,
+            match=room.match
+        ))()
+
+        add_score_to_team(room, room.match.correct_guess_score)
+
+        # TODO: Notify others
+        await self.channel_layer.group_send(self.room_group_name, {
+            'type':    'room_event',
+            'message': word.text
+        })
+
+    async def skip(self):
+        """
+        Skip current guessing word and decrease playing team score
+        by skip penalty
+
+        Only the explaining player can call this endpoint.
+
+        Return: A simple word that explaining player should explain
+        as next word
+
+        """
+        room = await get_room_and_check_turn(self.user, self.room_pk, [
+            Match.State.PLAYING,
+        ])
+
+        word = await get_random_word()
+        await database_sync_to_async(lambda: SelectedWord.objects.create(
+            text=word,
+            match=room.match
+        ))()
+
+        add_score_to_team(room, room.match.skip_penalty * -1)
+
+        # TODO: Notify others
+        await self.channel_layer.group_send(self.room_group_name, {
+            'type':    'room_event',
+            'message': word.text
+        })

--- a/core/routing.py
+++ b/core/routing.py
@@ -1,0 +1,8 @@
+# chat/routing.py
+from django.urls import re_path
+
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(r'ws/chat/(?P<pk>\w+)/$', consumers.TestConsumer.as_asgi()),
+]

--- a/core/templates/core/test.html
+++ b/core/templates/core/test.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <title>TEST</title>
+</head>
+
+<body>
+    <textarea id="chat-log" cols="100" rows="20"></textarea><br>
+    <input id="play" type="button" value="Play">
+    <input id="correct" type="button" value="Correct">
+    <input id="skip" type="button" value="Skip">
+    {{ room_name|json_script:"room-name" }}
+    <script>
+        const roomPK = JSON.parse(document.getElementById('room-name').textContent);
+
+        var wsUrl = 'ws://'
+            + window.location.host
+            + '/ws/chat/'
+            + roomPK
+            + '/';
+        const chatSocket = new WebSocket(wsUrl);
+
+        chatSocket.onmessage = function (e) {
+            const data = JSON.parse(e.data);
+            document.querySelector('#chat-log').value += (data.message + '\n');
+        };
+
+        chatSocket.onclose = function (e) {
+            console.error('Chat socket closed unexpectedly');
+        };
+
+        var httpUrlPrefix = "http://" + window.location.host + "/rooms/" + roomPK;
+        document.querySelector('#play').onclick = function (e) {
+            chatSocket.send(JSON.stringify({
+                action: "play"
+            }))
+        };
+        document.querySelector('#correct').onclick = function (e) {
+            chatSocket.send(JSON.stringify({
+                action: "correct"
+            }))
+        };
+        document.querySelector('#skip').onclick = function (e) {
+            chatSocket.send(JSON.stringify({
+                action: "skip"
+            }))
+        };
+    </script>
+</body>
+
+</html>

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,5 @@
 import json
 import random
-from copy import deepcopy
 from typing import Dict, List, Tuple
 
 from django.contrib.auth.models import User
@@ -8,14 +7,12 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from core.models import Match, Room, Word
-from core.views import get_words_all_indices
+from core.models import Room, Word
 
 
 class GerdTestCase(APITestCase):
     def setUp(self):
         self.users: Dict[str, User] = dict()
-        get_words_all_indices.cache_clear()
 
     def create_user(self, username: str = 'user') -> None:
         if username in self.users.keys():
@@ -424,212 +421,213 @@ class StartMatchTestCase(GerdTestCase):
         self.assertIn('started', response.data['detail'])
 
 
-class PlayMatchTestCase(GerdTestCase):
+# class PlayMatchTestCase(GerdTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.words = [
-            ('multiply', random.randint(1, 3)),
-            ('abiding', random.randint(1, 3)),
-            ('mask', random.randint(1, 3)),
-            ('trace', random.randint(1, 3)),
-            ('selection', random.randint(1, 3)),
-            ('real', random.randint(1, 3)),
-            ('pop', random.randint(1, 3)),
-            ('protective', random.randint(1, 3)),
-            ('certain', random.randint(1, 3)),
-            ('second', random.randint(1, 3)),
-            ('silly', random.randint(1, 3)),
-            ('sign', random.randint(1, 3)),
-            ('redo', random.randint(1, 3)),
-            ('middle', random.randint(1, 3)),
-            ('stale', random.randint(1, 3)),
-            ('daily', random.randint(1, 3)),
-            ('labored', random.randint(1, 3)),
-            ('broken', random.randint(1, 3)),
-            ('parsimonious', random.randint(1, 3)),
-            ('bite', random.randint(1, 3)),
-            ('forecast', random.randint(1, 3)),
-            ('aquatic', random.randint(1, 3)),
-        ]
-        self.create_words(self.words)
+#     def setUp(self):
+#         super().setUp()
+#         self.words = [
+#             ('multiply', random.randint(1, 3)),
+#             ('abiding', random.randint(1, 3)),
+#             ('mask', random.randint(1, 3)),
+#             ('trace', random.randint(1, 3)),
+#             ('selection', random.randint(1, 3)),
+#             ('real', random.randint(1, 3)),
+#             ('pop', random.randint(1, 3)),
+#             ('protective', random.randint(1, 3)),
+#             ('certain', random.randint(1, 3)),
+#             ('second', random.randint(1, 3)),
+#             ('silly', random.randint(1, 3)),
+#             ('sign', random.randint(1, 3)),
+#             ('redo', random.randint(1, 3)),
+#             ('middle', random.randint(1, 3)),
+#             ('stale', random.randint(1, 3)),
+#             ('daily', random.randint(1, 3)),
+#             ('labored', random.randint(1, 3)),
+#             ('broken', random.randint(1, 3)),
+#             ('parsimonious', random.randint(1, 3)),
+#             ('bite', random.randint(1, 3)),
+#             ('forecast', random.randint(1, 3)),
+#             ('aquatic', random.randint(1, 3)),
+#         ]
+#         self.create_words(self.words)
 
-        for i in range(6):
-            self.create_user(username=f'user{i}')
+#         for i in range(6):
+#             self.create_user(username=f'user{i}')
 
-        self.create_sample_room(creator='user1')
+#         self.create_sample_room(creator='user1')
 
-        self.join_room('user1')
-        self.join_room('user2')
-        self.join_room('user3')
-        self.join_room('user4')
+#         self.join_room('user1')
+#         self.join_room('user2')
+#         self.join_room('user3')
+#         self.join_room('user4')
 
-    def get_room(self, room_id: int = 1):
-        response = self.client.get(reverse('room-detail', args=[room_id]))
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        return response
+#     def get_room(self, room_id: int = 1):
+#         response = self.client.get(reverse('room-detail', args=[room_id]))
+#         self.assertEqual(status.HTTP_200_OK, response.status_code)
+#         return response
 
-    def get_explaining_player(self, room_id: int = 1):
-        response = self.get_room(room_id)
+#     def get_explaining_player(self, room_id: int = 1):
+#         response = self.get_room(room_id)
 
-        players = deepcopy(response.data['players'])
-        players.sort()
+#         players = deepcopy(response.data['players'])
+#         players.sort()
 
-        return players[response.data['match']['current_turn']]
+#         return players[response.data['match']['current_turn']]
 
-    def test_explaining_player_cannot_play_with_no_words(self):
-        self.remove_words()
-        self.start_match('user1')
+#     def test_explaining_player_cannot_play_with_no_words(self):
+#         self.remove_words()
+#         self.start_match('user1')
 
-        explaining_player = self.get_explaining_player()
+#         explaining_player = self.get_explaining_player()
 
-        token = self.users[explaining_player].auth_token
-        response = self.client.post(
-            reverse('play', args=[1]),
-            HTTP_AUTHORIZATION=f'Token {token}',
-        )
+#         token = self.users[explaining_player].auth_token
+#         response = self.client.post(
+#             reverse('play', args=[1]),
+#             HTTP_AUTHORIZATION=f'Token {token}',
+#         )
 
-        self.assertEqual(status.HTTP_503_SERVICE_UNAVAILABLE,
-                         response.status_code)
+#         self.assertEqual(status.HTTP_503_SERVICE_UNAVAILABLE,
+#                          response.status_code)
 
-    def test_explaining_player_can_call_play(self):
-        self.start_match('user1')
+#     def test_explaining_player_can_call_play(self):
+#         self.start_match('user1')
 
-        explaining_player = self.get_explaining_player()
+#         explaining_player = self.get_explaining_player()
 
-        token = self.users[explaining_player].auth_token
-        response = self.client.post(
-            reverse('play', args=[1]),
-            HTTP_AUTHORIZATION=f'Token {token}',
-        )
+#         token = self.users[explaining_player].auth_token
+#         response = self.client.post(
+#             reverse('play', args=[1]),
+#             HTTP_AUTHORIZATION=f'Token {token}',
+#         )
 
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertIn(response.data['word'], list(zip(*self.words))[0])
-        word = response.data['word']
+#         self.assertEqual(status.HTTP_200_OK, response.status_code)
+#         self.assertIn(response.data['word'], list(zip(*self.words))[0])
+#         word = response.data['word']
 
-        response = self.client.get(reverse('room-detail', args=[1]))
+#         response = self.client.get(reverse('room-detail', args=[1]))
 
-        self.assertEqual(word, response.data['match']['words'][0]['text'])
-        self.assertEqual(Match.State.PLAYING, response.data['match']['state'])
+#         self.assertEqual(word, response.data['match']['words'][0]['text'])
+#         self.assertEqual(Match.State.PLAYING,
+#              response.data['match']['state'])
 
-    def start_and_play(self, starter: str = 'user1'):
-        self.start_match(starter)
+#     def start_and_play(self, starter: str = 'user1'):
+#         self.start_match(starter)
 
-        explaining_player = self.get_explaining_player()
+#         explaining_player = self.get_explaining_player()
 
-        token = self.users[explaining_player].auth_token
-        response = self.client.post(
-            reverse('play', args=[1]),
-            HTTP_AUTHORIZATION=f'Token {token}',
-        )
+#         token = self.users[explaining_player].auth_token
+#         response = self.client.post(
+#             reverse('play', args=[1]),
+#             HTTP_AUTHORIZATION=f'Token {token}',
+#         )
 
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        return response
+#         self.assertEqual(status.HTTP_200_OK, response.status_code)
+#         return response
 
-    def test_players_can_not_call_play_twice(self):
-        self.start_and_play()
+#     def test_players_can_not_call_play_twice(self):
+#         self.start_and_play()
 
-        explaining_player = self.get_explaining_player()
-        token = self.users[explaining_player].auth_token
-        response = self.client.post(
-            reverse('play', args=[1]),
-            HTTP_AUTHORIZATION=f'Token {token}',
-        )
+#         explaining_player = self.get_explaining_player()
+#         token = self.users[explaining_player].auth_token
+#         response = self.client.post(
+#             reverse('play', args=[1]),
+#             HTTP_AUTHORIZATION=f'Token {token}',
+#         )
 
-        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
-        self.assertIn('state', response.data['detail'])
+#         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+#         self.assertIn('state', response.data['detail'])
 
-    def test_explaining_player_can_call_correct(self):
-        response = self.start_and_play()
-        word1 = response.data['word']
+#     def test_explaining_player_can_call_correct(self):
+#         response = self.start_and_play()
+#         word1 = response.data['word']
 
-        explaining_player = self.get_explaining_player()
-        token = self.users[explaining_player].auth_token
-        response = self.client.post(
-            reverse('correct', args=[1]),
-            HTTP_AUTHORIZATION=f'Token {token}',
-        )
+#         explaining_player = self.get_explaining_player()
+#         token = self.users[explaining_player].auth_token
+#         response = self.client.post(
+#             reverse('correct', args=[1]),
+#             HTTP_AUTHORIZATION=f'Token {token}',
+#         )
 
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        word2 = response.data['word']
+#         self.assertEqual(status.HTTP_200_OK, response.status_code)
+#         word2 = response.data['word']
 
-        response = self.get_room()
+#         response = self.get_room()
 
-        self.assertEqual(
-            Room.objects.get(pk=1).match.correct_guess_score,
-            response.data['match']['team_one_score']
-        )
+#         self.assertEqual(
+#             Room.objects.get(pk=1).match.correct_guess_score,
+#             response.data['match']['team_one_score']
+#         )
 
-        self.assertEqual(
-            0,
-            response.data['match']['team_two_score']
-        )
+#         self.assertEqual(
+#             0,
+#             response.data['match']['team_two_score']
+#         )
 
-        self.assertEqual(word1, response.data['match']['words'][0]['text'])
-        self.assertEqual(word2, response.data['match']['words'][1]['text'])
+#         self.assertEqual(word1, response.data['match']['words'][0]['text'])
+#         self.assertEqual(word2, response.data['match']['words'][1]['text'])
 
-    def test_explaining_player_can_call_skip(self):
-        self.start_and_play()
+#     def test_explaining_player_can_call_skip(self):
+#         self.start_and_play()
 
-        explaining_player = self.get_explaining_player()
-        token = self.users[explaining_player].auth_token
-        response = self.client.post(
-            reverse('skip', args=[1]),
-            HTTP_AUTHORIZATION=f'Token {token}',
-        )
+#         explaining_player = self.get_explaining_player()
+#         token = self.users[explaining_player].auth_token
+#         response = self.client.post(
+#             reverse('skip', args=[1]),
+#             HTTP_AUTHORIZATION=f'Token {token}',
+#         )
 
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        word = response.data['word']
+#         self.assertEqual(status.HTTP_200_OK, response.status_code)
+#         word = response.data['word']
 
-        response = self.get_room()
+#         response = self.get_room()
 
-        self.assertEqual(
-            Room.objects.get(pk=1).match.skip_penalty * -1,
-            response.data['match']['team_one_score']
-        )
+#         self.assertEqual(
+#             Room.objects.get(pk=1).match.skip_penalty * -1,
+#             response.data['match']['team_one_score']
+#         )
 
-        self.assertEqual(
-            0,
-            response.data['match']['team_two_score']
-        )
-        self.assertEqual(word, response.data['match']['words'][-1]['text'])
+#         self.assertEqual(
+#             0,
+#             response.data['match']['team_two_score']
+#         )
+#         self.assertEqual(word, response.data['match']['words'][-1]['text'])
 
-    def test_not_explaining_player_can_not_call_correct(self):
-        self.start_and_play()
+#     def test_not_explaining_player_can_not_call_correct(self):
+#         self.start_and_play()
 
-        response = self.get_room(1)
+#         response = self.get_room(1)
 
-        players = deepcopy(response.data['players'])
-        players.sort()
+#         players = deepcopy(response.data['players'])
+#         players.sort()
 
-        not_explaining_player = players[
-            (response.data['match']['current_turn'] + 1) % 4
-        ]
+#         not_explaining_player = players[
+#             (response.data['match']['current_turn'] + 1) % 4
+#         ]
 
-        token = self.users[not_explaining_player].auth_token
-        response = self.client.post(
-            reverse('correct', args=[1]),
-            HTTP_AUTHORIZATION=f'Token {token}',
-        )
+#         token = self.users[not_explaining_player].auth_token
+#         response = self.client.post(
+#             reverse('correct', args=[1]),
+#             HTTP_AUTHORIZATION=f'Token {token}',
+#         )
 
-        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+#         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_not_explaining_player_can_not_call_skip(self):
-        self.start_and_play()
+#     def test_not_explaining_player_can_not_call_skip(self):
+#         self.start_and_play()
 
-        response = self.get_room(1)
+#         response = self.get_room(1)
 
-        players = deepcopy(response.data['players'])
-        players.sort()
+#         players = deepcopy(response.data['players'])
+#         players.sort()
 
-        not_explaining_player = players[
-            (response.data['match']['current_turn'] + 1) % 4
-        ]
+#         not_explaining_player = players[
+#             (response.data['match']['current_turn'] + 1) % 4
+#         ]
 
-        token = self.users[not_explaining_player].auth_token
-        response = self.client.post(
-            reverse('skip', args=[1]),
-            HTTP_AUTHORIZATION=f'Token {token}',
-        )
+#         token = self.users[not_explaining_player].auth_token
+#         response = self.client.post(
+#             reverse('skip', args=[1]),
+#             HTTP_AUTHORIZATION=f'Token {token}',
+#         )
 
-        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+#         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)

--- a/core/views.py
+++ b/core/views.py
@@ -1,10 +1,5 @@
-import random
-from functools import cache
-from typing import List
-
 from django.db import transaction
-from django.shortcuts import get_object_or_404
-from django.utils import timezone
+from django.shortcuts import get_object_or_404, render
 from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import (APIException, PermissionDenied,
@@ -13,7 +8,7 @@ from rest_framework.permissions import (IsAuthenticated,
                                         IsAuthenticatedOrReadOnly)
 from rest_framework.response import Response
 
-from core.models import Match, Room, SelectedWord, Word
+from core.models import Match, Room
 from core.serializers import RoomSerializer
 
 
@@ -32,12 +27,6 @@ class LogicError(APIException):
     status_code = 400
     default_detail = 'Business logic error.'
     default_code = 'logic_error'
-
-
-class WordSetupError(APIException):
-    status_code = 503
-    default_detail = 'words are not available at the moment'
-    default_code = 'words_unavailable'
 
 
 @api_view(['POST'])
@@ -89,182 +78,6 @@ def start_match(request, pk):
     return Response(status=status.HTTP_200_OK)
 
 
-@cache
-def get_words_all_indices(complexity: int) -> List[int]:
-    """
-    Following query result will be cached, so we should reload
-    our web app after each time we modified `Word` table.
-    """
-    return Word.objects.filter(complexity=complexity).values_list(
-        'id', flat=True).order_by('id')
-
-
-def get_random_word() -> Word:
-    complexity = random.choices(
-        [
-            Word.Complexity.EASY,
-            Word.Complexity.INTERMEDIATE,
-            Word.Complexity.HARD,
-        ],
-        weights=[
-            4,
-            2,
-            1
-        ],
-        k=1
-    )
-    indices = get_words_all_indices(complexity[0])
-    if len(indices) == 0:
-        raise WordSetupError()
-    return Word.objects.get(pk=indices[random.randint(0, len(indices) - 1)])
-
-
-def get_room_and_check_turn(
-        request,
-        pk,
-        expected_states: List[Match.State]
-):
-
-    room = get_object_or_404(Room, pk=pk)
-    players = room.players.values_list(
-        'username', flat=True).order_by('username')
-    if request.user.username not in players:
-        raise PermissionDenied(detail='You are not member of this room')
-
-    if not hasattr(room, 'match'):
-        raise LogicError(detail='Room\'s match is not started yet')
-
-    if room.match.state not in expected_states:
-        raise LogicError(
-            detail=f'Match\'s state is not in {expected_states}'
-        )
-
-    if players[room.match.current_turn] != request.user.username:
-        raise PermissionDenied(detail='This is not your turn')
-
-    return room
-
-
-@api_view(['POST'])
-@permission_classes([IsAuthenticated])
-def play(request, pk):
-    """
-    Play match and return first word
-
-    Only the explaining player can call this endpoint.
-
-    Return: A simple word that explaining player should explain
-
-    """
-    room = get_room_and_check_turn(request, pk, [
-        Match.State.NEWBORN,
-        Match.State.WAITING,
-    ])
-
-    word = get_random_word()
-    SelectedWord.objects.create(
-        text=word,
-        match=room.match
-    )
-
-    room.match.state = Match.State.PLAYING
-    room.match.round_start_time = timezone.now()
-    room.match.save()
-
-    # TODO: Notify others
-
-    # TODO: Schedule round ending task using channel and native `await`
-    # https://github.com/django/channels/issues/814#issuecomment-354708463
-
-    return Response(
-        status=status.HTTP_200_OK,
-        data={'word': word.text}
-    )
-
-
-def add_score_to_team(room: Room, score: int, save: bool = True) -> None:
-    team = None
-    if room.teams == Room.Teams.ONE_TWO__THREE_FOUR:
-        team = 0 if room.match.current_turn in [0, 1] else 1
-    elif room.teams == Room.Teams.ONE_THREE__TWO_FOUR:
-        team = 0 if room.match.current_turn in [0, 2] else 1
-    elif room.teams == Room.Teams.ONE_FOUR__TWO_THREE:
-        team = 0 if room.match.current_turn in [0, 3] else 1
-
-    if team is None:
-        return
-
-    if team == 0:
-        room.match.team_one_score += score
-    else:
-        room.match.team_two_score += score
-
-    if save:
-        room.match.save()
-
-
-@api_view(['POST'])
-@permission_classes([IsAuthenticated])
-def correct(request, pk):
-    """
-    Add correct guess score to explaining player's team and get next word
-
-    Only the explaining player can call this endpoint.
-
-    Return: A simple word that explaining player should explain as next word
-
-    """
-    room = get_room_and_check_turn(request, pk, [
-        Match.State.PLAYING,
-    ])
-
-    word = get_random_word()
-    SelectedWord.objects.create(
-        text=word,
-        match=room.match
-    )
-
-    add_score_to_team(room, room.match.correct_guess_score)
-
-    # TODO: Notify others
-
-    return Response(
-        status=status.HTTP_200_OK,
-        data={'word': word.text}
-    )
-
-
-@api_view(['POST'])
-@permission_classes([IsAuthenticated])
-def skip(request, pk):
-    """
-    Skip current guessing word and decrease playing team score by skip penalty
-
-    Only the explaining player can call this endpoint.
-
-    Return: A simple word that explaining player should explain as next word
-
-    """
-    room = get_room_and_check_turn(request, pk, [
-        Match.State.PLAYING,
-    ])
-
-    word = get_random_word()
-    SelectedWord.objects.create(
-        text=word,
-        match=room.match
-    )
-
-    add_score_to_team(room, room.match.skip_penalty * -1)
-
-    # TODO: Notify others
-
-    return Response(
-        status=status.HTTP_200_OK,
-        data={'word': word.text}
-    )
-
-
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def rearrange(request, pk):
@@ -296,3 +109,9 @@ def rearrange(request, pk):
 
     # TODO: Notify others that teams changed
     return Response(status=status.HTTP_200_OK)
+
+
+def test(request, pk):
+    return render(request, 'core/test.html', {
+        'room_name': pk
+    })

--- a/gerd/asgi.py
+++ b/gerd/asgi.py
@@ -9,8 +9,19 @@ https://docs.djangoproject.com/en/4.0/howto/deployment/asgi/
 
 import os
 
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
+
+import core.routing
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gerd.settings')
 
-application = get_asgi_application()
+application = ProtocolTypeRouter({
+    "http": get_asgi_application(),
+    "websocket": AuthMiddlewareStack(
+        URLRouter(
+            core.routing.websocket_urlpatterns
+        )
+    ),
+})

--- a/gerd/settings.py
+++ b/gerd/settings.py
@@ -39,8 +39,19 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'core',
     'rest_framework',
-    'rest_framework.authtoken'
+    'rest_framework.authtoken',
+    'channels',
 ]
+
+ASGI_APPLICATION = 'gerd.asgi.application'
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels_redis.core.RedisChannelLayer',
+        'CONFIG': {
+            "hosts": [('127.0.0.1', 6379)],
+        },
+    },
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/gerd/urls.py
+++ b/gerd/urls.py
@@ -18,8 +18,8 @@ from django.urls import path
 from rest_framework.authtoken import views
 from rest_framework.documentation import include_docs_urls
 
-from core.views import (RoomDetail, RoomList, correct, join_room, play,
-                        rearrange, skip, start_match)
+from core.views import (RoomDetail, RoomList, join_room, rearrange,
+                        start_match, test)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -29,8 +29,7 @@ urlpatterns = [
     path('rooms/<int:pk>/', RoomDetail.as_view(), name='room-detail'),
     path('rooms/<int:pk>/join', join_room, name='join-room'),
     path('rooms/<int:pk>/start', start_match, name='start-room-match'),
-    path('rooms/<int:pk>/play', play, name='play'),
-    path('rooms/<int:pk>/correct', correct, name='correct'),
-    path('rooms/<int:pk>/skip', skip, name='skip'),
     path('rooms/<int:pk>/rearrange', rearrange, name='rearrange'),
+
+    path('test/<int:pk>/', test, name='test'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ isort==5.10.1
 autopep8==1.6.0
 flake8-isort==4.1.1
 coreapi==2.3.3
+channels==3.0.4
+channels_redis==3.3.1


### PR DESCRIPTION
Play, Correct, and Skip HTTP endpoints are now websocket actions.
Round timeout is implemented.
Websocket authorization is done via Django auth requiring sessions.
A simple template for testing the game is prepared.
Tests should be developed.
Probably needs refactoring.